### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/bechirjebali1/11885089-3489-41d7-a36c-a63af8faaacd/db34446d-a13f-485d-9a0a-06c28c0cf7c8/_apis/work/boardbadge/f2fac193-6b69-4cee-9e17-d3a843b3a028)](https://dev.azure.com/bechirjebali1/11885089-3489-41d7-a36c-a63af8faaacd/_boards/board/t/db34446d-a13f-485d-9a0a-06c28c0cf7c8/Microsoft.RequirementCategory)
 # Octocat Game
 Test your memory.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#54](https://dev.azure.com/bechirjebali1/11885089-3489-41d7-a36c-a63af8faaacd/_workitems/edit/54). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.